### PR TITLE
enable custom destination when sending scores to L1 via CCIP for contract wallets

### DIFF
--- a/contracts/DistributorSender.sol
+++ b/contracts/DistributorSender.sol
@@ -94,16 +94,22 @@ contract DistributorSender is Ownable {
 
     /// @notice Claim early user rewards
     /// @dev Epected to be called from rewarded users
-    /// @param target_ The address of the user who is rewarded
+    /// @param destinationChainSelector_ The selector of the target chain
+    /// @param receiver_ The address of the distributor receiver on the target chain
+    /// @param target_ The address of the user who has the score
+    /// @param destination_ The address of the user who is rewarded on the target chain
+    /// @param isClaim_ Claim rewards at the same time or not
     function sendScorePayNative(
         uint64 destinationChainSelector_,
         address receiver_,
         address target_,
+        address destination_,
         bool isClaim_
     )
         external
         payable
         onlyAllowlisted(destinationChainSelector_, receiver_)
+        onlyContributor(target_)
         returns (bytes32 messageId)
     {
         uint256 _score = scores[target_];
@@ -113,7 +119,7 @@ contract DistributorSender is Ownable {
 
         Client.EVM2AnyMessage memory encodedMessage = _buildCCIPMessage(
             receiver_,
-            target_,
+            destination_,
             _score,
             isClaim_,
             address(0)
@@ -129,21 +135,27 @@ contract DistributorSender is Ownable {
             encodedMessage
         );
 
-        emit ScoreSent(messageId, target_, _score);
+        emit ScoreSent(messageId, destination_, _score);
     }
 
     /// @notice Claim early user rewards
     /// @dev Epected to be called from rewarded users
-    /// @param target_ The address of the user who is rewarded
+    /// @param receiver_ The address of the distributor receiver on the target chain
+    /// @param target_ The address of the user who has the score
+    /// @param destination_ The address of the user who is rewarded on the target chain
+    /// @param isClaim_ Claim rewards at the same time or not
+    /// @param payToken_ Token address for paying fee
     function sendScorePayToken(
         uint64 destinationChainSelector_,
         address receiver_,
         address target_,
+        address destination_,
         bool isClaim_,
         address payToken_
     )
         external
         onlyAllowlisted(destinationChainSelector_, receiver_)
+        onlyContributor(target_)
         returns (bytes32 messageId)
     {
         uint256 _score = scores[target_];
@@ -153,7 +165,7 @@ contract DistributorSender is Ownable {
 
         Client.EVM2AnyMessage memory encodedMessage = _buildCCIPMessage(
             receiver_,
-            target_,
+            destination_,
             _score,
             isClaim_,
             payToken_
@@ -168,19 +180,19 @@ contract DistributorSender is Ownable {
         // Send the CCIP message through the router and store the returned CCIP message ID
         messageId = router.ccipSend(destinationChainSelector_, encodedMessage);
 
-        emit ScoreSent(messageId, target_, _score);
+        emit ScoreSent(messageId, destination_, _score);
     }
 
     /// @notice Construct a CCIP message.
     /// @dev This function will create an EVM2AnyMessage struct with all the necessary information for sending a text.
     /// @param _receiver The address of the receiver.
-    /// @param _target The string data to be sent.
+    /// @param _destination The string data to be sent.
     /// @param _amount The string data to be sent.
     /// @param _feeToken The address of the token used for fees. Set address(0) for native gas.
     /// @return Client.EVM2AnyMessage Returns an EVM2AnyMessage struct which contains information for sending a CCIP message.
     function _buildCCIPMessage(
         address _receiver,
-        address _target,
+        address _destination,
         uint256 _amount,
         bool _isClaim,
         address _feeToken
@@ -189,7 +201,7 @@ contract DistributorSender is Ownable {
         return
             Client.EVM2AnyMessage({
                 receiver: abi.encode(_receiver), // ABI-encoded receiver address
-                data: abi.encode(_target, _amount, _isClaim), // ABI-encoded string
+                data: abi.encode(_destination, _amount, _isClaim), // ABI-encoded string
                 tokenAmounts: new Client.EVMTokenAmount[](0), // Empty array aas no tokens are transferred
                 extraArgs: "",
                 // Set the feeToken to a feeTokenAddress, indicating specific asset will be used for fees
@@ -200,6 +212,12 @@ contract DistributorSender is Ownable {
     /// @dev Allow only scorers who is registered in Factory
     modifier onlyAuction() {
         require(factory.auctions(msg.sender), "You are not the auction.");
+        _;
+    }
+
+    /// @dev Allow only contributor for claim
+    modifier onlyContributor(address _contributor) {
+        require(msg.sender == _contributor, "You are not the contributor.");
         _;
     }
 }

--- a/contracts/DistributorSender.sol
+++ b/contracts/DistributorSender.sol
@@ -96,26 +96,23 @@ contract DistributorSender is Ownable {
     /// @dev Epected to be called from rewarded users
     /// @param destinationChainSelector_ The selector of the target chain
     /// @param receiver_ The address of the distributor receiver on the target chain
-    /// @param target_ The address of the user who has the score
     /// @param destination_ The address of the user who is rewarded on the target chain
     /// @param isClaim_ Claim rewards at the same time or not
     function sendScorePayNative(
         uint64 destinationChainSelector_,
         address receiver_,
-        address target_,
         address destination_,
         bool isClaim_
     )
         external
         payable
         onlyAllowlisted(destinationChainSelector_, receiver_)
-        onlyContributor(target_)
         returns (bytes32 messageId)
     {
-        uint256 _score = scores[target_];
+        uint256 _score = scores[msg.sender];
         require(_score > 0, "Not eligible to get rewarded");
 
-        scores[target_] = 0;
+        scores[msg.sender] = 0;
 
         Client.EVM2AnyMessage memory encodedMessage = _buildCCIPMessage(
             receiver_,
@@ -141,27 +138,24 @@ contract DistributorSender is Ownable {
     /// @notice Claim early user rewards
     /// @dev Epected to be called from rewarded users
     /// @param receiver_ The address of the distributor receiver on the target chain
-    /// @param target_ The address of the user who has the score
     /// @param destination_ The address of the user who is rewarded on the target chain
     /// @param isClaim_ Claim rewards at the same time or not
     /// @param payToken_ Token address for paying fee
     function sendScorePayToken(
         uint64 destinationChainSelector_,
         address receiver_,
-        address target_,
         address destination_,
         bool isClaim_,
         address payToken_
     )
         external
         onlyAllowlisted(destinationChainSelector_, receiver_)
-        onlyContributor(target_)
         returns (bytes32 messageId)
     {
-        uint256 _score = scores[target_];
+        uint256 _score = scores[msg.sender];
         require(_score > 0, "Not eligible to get rewarded");
 
-        scores[target_] = 0;
+        scores[msg.sender] = 0;
 
         Client.EVM2AnyMessage memory encodedMessage = _buildCCIPMessage(
             receiver_,
@@ -212,12 +206,6 @@ contract DistributorSender is Ownable {
     /// @dev Allow only scorers who is registered in Factory
     modifier onlyAuction() {
         require(factory.auctions(msg.sender), "You are not the auction.");
-        _;
-    }
-
-    /// @dev Allow only contributor for claim
-    modifier onlyContributor(address _contributor) {
-        require(msg.sender == _contributor, "You are not the contributor.");
         _;
     }
 }

--- a/test/distributorCCIP.ts
+++ b/test/distributorCCIP.ts
@@ -298,6 +298,7 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
+              addr1.address,
               false,
               { value: feeAmount },
             ),
@@ -393,6 +394,7 @@ describe("DistributorCCIP", function () {
             .sendScorePayToken(
               chainSelector,
               distributorReceiver.target,
+              addr1.address,
               addr1.address,
               false,
               linkToken,
@@ -490,6 +492,7 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
+              addr1.address,
               true,
               { value: feeAmount },
             ),
@@ -504,8 +507,366 @@ describe("DistributorCCIP", function () {
         );
       });
 
-      // 別アドレス宛のクレーム
+      // L1の別アドレス宛へのスコア送信（Native）
       it("claim_success_4", async function () {
+        const {
+          factory,
+          chainSelector,
+          distributorSender,
+          distributorReceiver,
+          ymwk,
+          owner,
+          addr1,
+          addr2,
+        } = await loadFixture(deployFactoryAndTemplateFixture);
+
+        await distributorSender.setAllowlistDestinationChainSender(
+          chainSelector,
+          distributorReceiver.target,
+          true,
+        );
+        await distributorReceiver.setAllowlistSourceChainSender(
+          chainSelector,
+          distributorSender.target,
+          true,
+        );
+
+        ymwk.transfer(distributorReceiver.target, ethers.parseEther("1000"));
+
+        const { token } = await loadFixture(deployTokenFixture);
+        const allocatedAmount = ethers.parseEther("100");
+        await token.approve(factory.target, allocatedAmount);
+        const now = await time.latest();
+
+        const sale = await deploySaleTemplate(
+          factory,
+          await token.getAddress(),
+          owner.address,
+          allocatedAmount,
+          now + DAY,
+          DAY,
+          "0",
+          undefined,
+          templateNameSender,
+        );
+
+        await timeTravel(DAY);
+
+        await sendEther(sale.target, "1", addr1);
+
+        await timeTravel(DAY);
+
+        await sale.connect(addr1).claim(addr1.address, addr1.address);
+
+        const message = {
+          receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
+          data: abiCoder.encode(
+            ["address", "uint256", "bool"],
+            [addr2.address, ethers.parseEther("100"), true],
+          ),
+          tokenAmounts: [],
+          extraArgs: "0x",
+          feeToken: ethers.ZeroAddress,
+        };
+
+        const router = await ethers.getContractAt(
+          "IRouterClient",
+          await distributorSender.router(),
+        );
+        const feeAmount = await router.getFee(chainSelector, message);
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("100"),
+        );
+        expect(await distributorSender.scores(addr2.address)).to.be.equal("0");
+
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          "0",
+        );
+        expect(await distributorReceiver.scores(addr2.address)).to.be.equal(
+          "0",
+        );
+        expect(await ymwk.balanceOf(addr1.address)).to.be.equal("0");
+        expect(await ymwk.balanceOf(addr2.address)).to.be.equal("0");
+
+        await expect(
+          distributorSender
+            .connect(addr1)
+            .sendScorePayNative(
+              chainSelector,
+              distributorReceiver.target,
+              addr1.address,
+              addr2.address,
+              true,
+              { value: feeAmount },
+            ),
+        ).to.not.be.reverted;
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal("0");
+        expect(await distributorSender.scores(addr2.address)).to.be.equal("0");
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("0"),
+        );
+        expect(await distributorReceiver.scores(addr2.address)).to.be.equal(
+          ethers.parseEther("0"),
+        );
+        expect(await ymwk.balanceOf(addr1.address)).to.be.equal("0");
+        expect(await ymwk.balanceOf(addr2.address)).to.be.equal(
+          ethers.parseEther("100"),
+        );
+      });
+
+      // L1の別アドレス宛へのスコア送信（Token）
+      it("claim_success_5", async function () {
+        const {
+          factory,
+          chainSelector,
+          distributorSender,
+          distributorReceiver,
+          linkToken,
+          ymwk,
+          owner,
+          addr1,
+          addr2,
+        } = await loadFixture(deployFactoryAndTemplateFixture);
+
+        linkToken.transfer(addr1.address, ethers.parseEther("0.1"));
+
+        await distributorSender.setAllowlistDestinationChainSender(
+          chainSelector,
+          distributorReceiver.target,
+          true,
+        );
+        await distributorReceiver.setAllowlistSourceChainSender(
+          chainSelector,
+          distributorSender.target,
+          true,
+        );
+
+        ymwk.transfer(distributorReceiver.target, ethers.parseEther("1000"));
+
+        const { token } = await loadFixture(deployTokenFixture);
+        const allocatedAmount = ethers.parseEther("100");
+        await token.approve(factory.target, allocatedAmount);
+        const now = await time.latest();
+
+        const sale = await deploySaleTemplate(
+          factory,
+          await token.getAddress(),
+          owner.address,
+          allocatedAmount,
+          now + DAY,
+          DAY,
+          "0",
+          undefined,
+          templateNameSender,
+        );
+
+        await timeTravel(DAY);
+
+        await sendEther(sale.target, "1", addr1);
+
+        await timeTravel(DAY);
+
+        await sale.connect(addr1).claim(addr1.address, addr1.address);
+
+        const message = {
+          receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
+          data: abiCoder.encode(
+            ["address", "uint256", "bool"],
+            [addr2.address, ethers.parseEther("100"), true],
+          ),
+          tokenAmounts: [],
+          extraArgs: "0x",
+          feeToken: linkToken.target,
+        };
+
+        const router = await ethers.getContractAt(
+          "IRouterClient",
+          await distributorSender.router(),
+        );
+        const feeAmount = await router.getFee(chainSelector, message);
+
+        await linkToken
+          .connect(addr1)
+          .approve(distributorSender.target, feeAmount);
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("100"),
+        );
+        expect(await distributorSender.scores(addr2.address)).to.be.equal("0");
+
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          "0",
+        );
+        expect(await distributorReceiver.scores(addr2.address)).to.be.equal(
+          "0",
+        );
+        expect(await ymwk.balanceOf(addr1.address)).to.be.equal("0");
+        expect(await ymwk.balanceOf(addr2.address)).to.be.equal("0");
+
+        await expect(
+          distributorSender
+            .connect(addr1)
+            .sendScorePayToken(
+              chainSelector,
+              distributorReceiver.target,
+              addr1.address,
+              addr2.address,
+              true,
+              linkToken,
+            ),
+        ).to.not.be.reverted;
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal("0");
+        expect(await distributorSender.scores(addr2.address)).to.be.equal("0");
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("0"),
+        );
+        expect(await distributorReceiver.scores(addr2.address)).to.be.equal(
+          ethers.parseEther("0"),
+        );
+        expect(await ymwk.balanceOf(addr1.address)).to.be.equal("0");
+        expect(await ymwk.balanceOf(addr2.address)).to.be.equal(
+          ethers.parseEther("100"),
+        );
+      });
+
+      // sender,receiverの設定不足エラー
+      it("claim_fail_1", async function () {
+        const {
+          factory,
+          chainSelector,
+          distributorSender,
+          distributorReceiver,
+          owner,
+          addr1,
+        } = await loadFixture(deployFactoryAndTemplateFixture);
+
+        const { token } = await loadFixture(deployTokenFixture);
+        const allocatedAmount = ethers.parseEther("100");
+        await token.approve(factory.target, allocatedAmount);
+        const now = await time.latest();
+
+        const sale = await deploySaleTemplate(
+          factory,
+          await token.getAddress(),
+          owner.address,
+          allocatedAmount,
+          now + DAY,
+          DAY,
+          "0",
+          undefined,
+          templateNameSender,
+        );
+
+        await timeTravel(DAY);
+
+        await sendEther(sale.target, "1", addr1);
+
+        await timeTravel(DAY);
+
+        await sale.connect(addr1).claim(addr1.address, addr1.address);
+
+        const message = {
+          receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
+          data: abiCoder.encode(
+            ["address", "uint256", "bool"],
+            [addr1.address, ethers.parseEther("100"), false],
+          ),
+          tokenAmounts: [],
+          extraArgs: "0x",
+          feeToken: ethers.ZeroAddress,
+        };
+
+        const router = await ethers.getContractAt(
+          "IRouterClient",
+          await distributorSender.router(),
+        );
+        const feeAmount = await router.getFee(chainSelector, message);
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("100"),
+        );
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          "0",
+        );
+
+        await expect(
+          distributorSender
+            .connect(addr1)
+            .sendScorePayNative(
+              chainSelector,
+              distributorReceiver.target,
+              addr1.address,
+              addr1.address,
+              false,
+              { value: feeAmount },
+            ),
+        ).to.be.reverted;
+      });
+
+      // スコアがないユーザのクレーム
+      it("claim_fail_2", async function () {
+        const {
+          factory,
+          chainSelector,
+          distributorSender,
+          distributorReceiver,
+          addr1,
+        } = await loadFixture(deployFactoryAndTemplateFixture);
+
+        await distributorSender.setAllowlistDestinationChainSender(
+          chainSelector,
+          distributorReceiver.target,
+          true,
+        );
+        await distributorReceiver.setAllowlistSourceChainSender(
+          chainSelector,
+          distributorSender.target,
+          true,
+        );
+
+        const message = {
+          receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
+          data: abiCoder.encode(
+            ["address", "uint256", "bool"],
+            [addr1.address, ethers.parseEther("100"), false],
+          ),
+          tokenAmounts: [],
+          extraArgs: "0x",
+          feeToken: ethers.ZeroAddress,
+        };
+
+        const router = await ethers.getContractAt(
+          "IRouterClient",
+          await distributorSender.router(),
+        );
+        const feeAmount = await router.getFee(chainSelector, message);
+
+        expect(await distributorSender.scores(addr1.address)).to.be.equal(
+          ethers.parseEther("0"),
+        );
+        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
+          "0",
+        );
+
+        await expect(
+          distributorSender
+            .connect(addr1)
+            .sendScorePayNative(
+              chainSelector,
+              distributorReceiver.target,
+              addr1.address,
+              addr1.address,
+              false,
+              { value: feeAmount },
+            ),
+        ).to.be.revertedWith("Not eligible to get rewarded");
+      });
+
+      // 別アドレス宛のクレーム（ownerがaddr1のスコア送信, Native）
+      it("claim_fail_3", async function () {
         const {
           factory,
           chainSelector,
@@ -584,30 +945,40 @@ describe("DistributorCCIP", function () {
             chainSelector,
             distributorReceiver.target,
             addr1.address,
+            addr1.address,
             true,
             { value: feeAmount },
           ),
-        ).to.not.be.reverted;
-
-        expect(await distributorSender.scores(addr1.address)).to.be.equal("0");
-        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
-          ethers.parseEther("0"),
-        );
-        expect(await ymwk.balanceOf(addr1.address)).to.be.equal(
-          ethers.parseEther("100"),
-        );
+        ).to.be.revertedWith("You are not the contributor.");
       });
 
-      // sender,receiverの設定不足エラー
-      it("claim_fail_1", async function () {
+      // 別アドレス宛のクレーム（ownerがaddr1のスコア送信, Native）
+      it("claim_fail_3", async function () {
         const {
           factory,
           chainSelector,
           distributorSender,
           distributorReceiver,
+          linkToken,
+          ymwk,
           owner,
           addr1,
+          addr2,
         } = await loadFixture(deployFactoryAndTemplateFixture);
+
+        await distributorSender.setAllowlistDestinationChainSender(
+          chainSelector,
+          distributorReceiver.target,
+          true,
+        );
+        await distributorReceiver.setAllowlistSourceChainSender(
+          chainSelector,
+          distributorSender.target,
+          true,
+        );
+
+        ymwk.transfer(distributorReceiver.target, ethers.parseEther("1000"));
+        linkToken.transfer(addr1.address, ethers.parseEther("0.1"));
 
         const { token } = await loadFixture(deployTokenFixture);
         const allocatedAmount = ethers.parseEther("100");
@@ -638,11 +1009,11 @@ describe("DistributorCCIP", function () {
           receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
           data: abiCoder.encode(
             ["address", "uint256", "bool"],
-            [addr1.address, ethers.parseEther("100"), false],
+            [addr1.address, ethers.parseEther("100"), true],
           ),
           tokenAmounts: [],
           extraArgs: "0x",
-          feeToken: ethers.ZeroAddress,
+          feeToken: linkToken.target,
         };
 
         const router = await ethers.getContractAt(
@@ -650,6 +1021,10 @@ describe("DistributorCCIP", function () {
           await distributorSender.router(),
         );
         const feeAmount = await router.getFee(chainSelector, message);
+
+        await linkToken
+          .connect(addr1)
+          .approve(distributorSender.target, feeAmount);
 
         expect(await distributorSender.scores(addr1.address)).to.be.equal(
           ethers.parseEther("100"),
@@ -657,72 +1032,18 @@ describe("DistributorCCIP", function () {
         expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
           "0",
         );
+        expect(await ymwk.balanceOf(addr1.address)).to.be.equal("0");
 
         await expect(
-          distributorSender.sendScorePayNative(
+          distributorSender.sendScorePayToken(
             chainSelector,
             distributorReceiver.target,
             addr1.address,
-            false,
-            { value: feeAmount },
+            addr2.address,
+            true,
+            linkToken,
           ),
-        ).to.be.reverted;
-      });
-
-      // スコアがないユーザのクレーム
-      it("claim_fail_2", async function () {
-        const {
-          factory,
-          chainSelector,
-          distributorSender,
-          distributorReceiver,
-          addr1,
-        } = await loadFixture(deployFactoryAndTemplateFixture);
-
-        await distributorSender.setAllowlistDestinationChainSender(
-          chainSelector,
-          distributorReceiver.target,
-          true,
-        );
-        await distributorReceiver.setAllowlistSourceChainSender(
-          chainSelector,
-          distributorSender.target,
-          true,
-        );
-
-        const message = {
-          receiver: abiCoder.encode(["bytes"], [distributorReceiver.target]),
-          data: abiCoder.encode(
-            ["address", "uint256", "bool"],
-            [addr1.address, ethers.parseEther("100"), false],
-          ),
-          tokenAmounts: [],
-          extraArgs: "0x",
-          feeToken: ethers.ZeroAddress,
-        };
-
-        const router = await ethers.getContractAt(
-          "IRouterClient",
-          await distributorSender.router(),
-        );
-        const feeAmount = await router.getFee(chainSelector, message);
-
-        expect(await distributorSender.scores(addr1.address)).to.be.equal(
-          ethers.parseEther("0"),
-        );
-        expect(await distributorReceiver.scores(addr1.address)).to.be.equal(
-          "0",
-        );
-
-        await expect(
-          distributorSender.sendScorePayNative(
-            chainSelector,
-            distributorReceiver.target,
-            addr1.address,
-            false,
-            { value: feeAmount },
-          ),
-        ).to.be.revertedWith("Not eligible to get rewarded");
+        ).to.be.revertedWith("You are not the contributor.");
       });
     });
   });

--- a/test/distributorCCIP.ts
+++ b/test/distributorCCIP.ts
@@ -298,7 +298,6 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
-              addr1.address,
               false,
               { value: feeAmount },
             ),
@@ -395,7 +394,6 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
-              addr1.address,
               false,
               linkToken,
             ),
@@ -491,7 +489,6 @@ describe("DistributorCCIP", function () {
             .sendScorePayNative(
               chainSelector,
               distributorReceiver.target,
-              addr1.address,
               addr1.address,
               true,
               { value: feeAmount },
@@ -595,7 +592,6 @@ describe("DistributorCCIP", function () {
             .sendScorePayNative(
               chainSelector,
               distributorReceiver.target,
-              addr1.address,
               addr2.address,
               true,
               { value: feeAmount },
@@ -711,7 +707,6 @@ describe("DistributorCCIP", function () {
             .sendScorePayToken(
               chainSelector,
               distributorReceiver.target,
-              addr1.address,
               addr2.address,
               true,
               linkToken,
@@ -799,7 +794,6 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
-              addr1.address,
               false,
               { value: feeAmount },
             ),
@@ -858,14 +852,13 @@ describe("DistributorCCIP", function () {
               chainSelector,
               distributorReceiver.target,
               addr1.address,
-              addr1.address,
               false,
               { value: feeAmount },
             ),
         ).to.be.revertedWith("Not eligible to get rewarded");
       });
 
-      // 別アドレス宛のクレーム（ownerがaddr1のスコア送信, Native）
+      // スコアが無いアドレスから別アドレス宛のクレーム（ownerがaddr1へスコア送信, Native）
       it("claim_fail_3", async function () {
         const {
           factory,
@@ -945,14 +938,13 @@ describe("DistributorCCIP", function () {
             chainSelector,
             distributorReceiver.target,
             addr1.address,
-            addr1.address,
             true,
             { value: feeAmount },
           ),
-        ).to.be.revertedWith("You are not the contributor.");
+        ).to.be.revertedWith("Not eligible to get rewarded");
       });
 
-      // 別アドレス宛のクレーム（ownerがaddr1のスコア送信, Native）
+      // スコアが無いアドレスから別アドレス宛のクレーム（ownerがaddr1へスコア送信, Token
       it("claim_fail_3", async function () {
         const {
           factory,
@@ -1038,12 +1030,11 @@ describe("DistributorCCIP", function () {
           distributorSender.sendScorePayToken(
             chainSelector,
             distributorReceiver.target,
-            addr1.address,
             addr2.address,
             true,
             linkToken,
           ),
-        ).to.be.revertedWith("You are not the contributor.");
+        ).to.be.revertedWith("Not eligible to get rewarded");
       });
     });
   });


### PR DESCRIPTION
コントラクトウォレットの場合L1の送信先アドレスを指定する必要がある

DistributorSenderのsendScorePayNative、sendScorePayTokenでそれぞれ
- destination_を別途指定できるように変更
- スコア保有者本人のみが操作できるように変更